### PR TITLE
Remove pos_visibility_check() call

### DIFF
--- a/admin/class-pos-admin.php
+++ b/admin/class-pos-admin.php
@@ -216,9 +216,6 @@ class WooCommerce_POS_Admin {
 
 		// set the auto redirection on next page load
 		set_transient( 'woocommere_pos_welcome', 1, 30 );
-
-		// check _pos_visibility on upgrade
-		self::pos_visibility_check();
 	}
 
 	/**


### PR DESCRIPTION
WooCommerce_POS_Admin::pos_visibility_check() was removed, but a call was still being made. This causes an error on install.
