### PR TITLE
Add filter to thumbnail image

### DIFF
--- a/includes/api/products.php
+++ b/includes/api/products.php
@@ -290,7 +290,7 @@ class Products extends WC_API_Resource {
     if( is_array($image) )
       return $image[0];
 
-    return wc_placeholder_img_src();
+    return apply_filters( 'woocommerce_pos_placeholder_img_src', wc_placeholder_img_src(), $id );
   }
 
   /**


### PR DESCRIPTION
We store an external image in post meta for our products. We weren't able to hook into the prior calls to perform what we were needing to accomplish due to the post ID / product ID not being available globally. Due to this, the easiest thing would be to be able to view what was about to be returned via the get_thumbnail function, along with the product ID. We then take the ID, check if a product image exists in our post meta, and if so, update the return value.