### PR TITLE
Created a 'pos_check' gateway.

### DIFF
--- a/includes/gateways.php
+++ b/includes/gateways.php
@@ -53,7 +53,8 @@ class Gateways {
 
     return array_merge($gateways, array(
       'WC_POS\Gateways\Cash',
-      'WC_POS\Gateways\Card'
+      'WC_POS\Gateways\Card',
+      'WC_POS\Gateways\Check'
     ));
   }
 
@@ -64,7 +65,7 @@ class Gateways {
    */
   public function load_gateways( $gateways ) {
     foreach( $gateways as $gateway ){
-      $gateway->pos = in_array( $gateway->id, array( 'pos_cash', 'pos_card', 'paypal' ) );
+      $gateway->pos = in_array( $gateway->id, array( 'pos_cash', 'pos_card', 'pos_check', 'paypal' ) );
     }
     return $gateways;
   }

--- a/includes/gateways/check.php
+++ b/includes/gateways/check.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * Provides a Check Payment Gateway.
+ *
+ * @class       WC_POS_Gateways_Check
+ * @package     WooCommerce POS
+ * @author      Paul Kilmurray <paul@kilbot.com.au>
+ * @link        http://www.wcpos.com
+ * @extends     WC_Payment_Gateway
+ */
+
+ //Simply copied from card.php and all references to card were changed to check.
+
+namespace WC_POS\Gateways;
+
+use WC_Order;
+use WC_Payment_Gateway;
+use WC_POS\API;
+
+class Check extends WC_Payment_Gateway {
+
+  /**
+   * Constructor for the gateway.
+   */
+  public function __construct() {
+    $this->id           = 'pos_check';
+    $this->title        = __( 'Check', 'woocommerce-pos' );
+    $this->description  = '';
+    $this->icon         = apply_filters( 'woocommerce_pos_check_icon', '' );
+    $this->has_fields   = true;
+
+    // Actions
+    add_action( 'woocommerce_pos_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
+    add_action( 'woocommerce_thankyou_pos_check', array( $this, 'calculate_cashback' ) );
+
+  }
+
+  /**
+   * Display the payment fields in the checkout
+   */
+  public function payment_fields() {
+
+    if ( $this->description ) {
+      echo '<p>' . wp_kses_post( $this->description ) . '</p>';
+    }
+
+    $currency_pos = get_option( 'woocommerce_currency_pos' );
+
+    if( $currency_pos == 'left' || 'left_space') {
+      $left_addon = '<span class="input-group-addon">'. get_woocommerce_currency_symbol( get_woocommerce_currency() ) .'</span>';
+      $right_addon = '';
+    } else {
+      $left_addon = '';
+      $right_addon = '<span class="input-group-addon">'. get_woocommerce_currency_symbol( get_woocommerce_currency() ) .'</span>';
+    }
+
+    echo '
+      <div class="form-row " id="pos-cashback_field">
+        <label for="pos-cashback" class="">'. __('Cashback', 'woocommerce-pos') .'</label>
+        <div class="input-group">
+        '. $left_addon .'
+          <input type="text" class="form-control" name="pos-cashback" id="pos-cashback" placeholder="" maxlength="20" data-value="0" data-numpad="cash" data-label="'. __('Cashback', 'woocommerce-pos') .'">
+        '. $right_addon .'
+        </div>
+      </div>
+    ';
+
+  }
+
+  /**
+   * @param int $order_id
+   * @return array
+   */
+  public function process_payment( $order_id ) {
+
+    // get order object
+    $order = new WC_Order( $order_id );
+
+    // update pos_cash data
+    $data = API::get_raw_data();
+    $cashback = isset( $data['payment_details']['pos-cashback'] ) ? wc_format_decimal( $data['payment_details']['pos-cashback'] ) : 0 ;
+
+    if( $cashback !== 0 ) {
+
+      // add order meta
+      update_post_meta( $order_id, '_pos_check_cashback', $cashback );
+
+      // add cashback as fee line item
+      // TODO: this should be handled by $order->add_fee after WC 2.2
+      $item_id = wc_add_order_item( $order_id, array(
+        'order_item_name' => __('Cashback', 'woocommerce-pos'),
+        'order_item_type' => 'fee'
+      ) );
+
+      if ( $item_id ) {
+        wc_add_order_item_meta( $item_id, '_line_total', $cashback );
+        wc_add_order_item_meta( $item_id, '_line_tax', 0 );
+        wc_add_order_item_meta( $item_id, '_line_subtotal', $cashback );
+        wc_add_order_item_meta( $item_id, '_line_subtotal_tax', 0 );
+        wc_add_order_item_meta( $item_id, '_tax_class', 'zero-rate' );
+      }
+
+      // update the order total to include fee
+      $order_total = get_post_meta( $order_id, '_order_total', true );
+      $order_total += $cashback;
+      update_post_meta( $order_id, '_order_total', $order_total );
+
+    }
+
+    // payment complete
+    $order->payment_complete();
+
+    // success
+    return array(
+      'result' => 'success'
+    );
+  }
+
+  public function calculate_cashback( $order_id ) {
+    $message = '';
+    $cashback = get_post_meta( $order_id, '_pos_check_cashback', true );
+
+    // construct message
+    if( $cashback ) {
+      $message = __('Cashback', 'woocommerce-pos') . ': ';
+      $message .= wc_price($cashback);
+    }
+
+    echo $message;
+  }
+
+}

--- a/languages/woocommerce-pos.pot
+++ b/languages/woocommerce-pos.pot
@@ -444,14 +444,14 @@ msgstr ""
 msgid "Amount Tendered"
 msgstr ""
 
-#: includes/gateways/class-wc-pos-cash.php:28
+#: includes/gateways/class-wc-pos-check.php:28
 msgid "Check"
 msgstr ""
 
-#: includes/gateways/class-wc-pos-card.php:60
-#: includes/gateways/class-wc-pos-card.php:63
-#: includes/gateways/class-wc-pos-card.php:92
-#: includes/gateways/class-wc-pos-card.php:126
+#: includes/gateways/class-wc-pos-check.php:60
+#: includes/gateways/class-wc-pos-check.php:63
+#: includes/gateways/class-wc-pos-check.php:92
+#: includes/gateways/class-wc-pos-check.php:126
 msgid "Cashback"
 msgstr ""
 

--- a/languages/woocommerce-pos.pot
+++ b/languages/woocommerce-pos.pot
@@ -444,6 +444,17 @@ msgstr ""
 msgid "Amount Tendered"
 msgstr ""
 
+#: includes/gateways/class-wc-pos-cash.php:28
+msgid "Check"
+msgstr ""
+
+#: includes/gateways/class-wc-pos-card.php:60
+#: includes/gateways/class-wc-pos-card.php:63
+#: includes/gateways/class-wc-pos-card.php:92
+#: includes/gateways/class-wc-pos-card.php:126
+msgid "Cashback"
+msgstr ""
+
 #: includes/products/class-wc-pos-visibility.php:23
 msgid "POS & Online"
 msgstr ""


### PR DESCRIPTION
It is necessary to have a 'pos_check' gateway even though there is a 'cheque' gateway built into woocommerce.  This is because the use cases are different.  It is completely logical for the built in gateway to set orders to 'on-hold' as the check would have to be mailed in.  For a POS, that is a very inconvenient way to handle it.  A check will always be provided at the moment of the sale, therefore it should be marked as completed immediately.

Because of these differences, the built in gateway will never be changed, and most likely, neither will a filter be introduced into woocommerce to make this behavior tweakable.