### PR TITLE
Should fix POS Pro custom templates not found

### DIFF
--- a/includes/class-wc-pos-template.php
+++ b/includes/class-wc-pos-template.php
@@ -336,7 +336,7 @@ class WC_POS_Template {
   static public function locate_template_files( $partials_dir = '' ) {
     $files = array();
     foreach ( self::locate_default_template_files( $partials_dir ) as $slug => $path ) {
-      $files[ $slug ] = self::locate_template_file( $path );
+      $files[ $slug ] = self::locate_template_file( $path, $partials_dir );
     };
 
     return $files;
@@ -348,8 +348,8 @@ class WC_POS_Template {
    * @param string $default_path
    * @return string
    */
-  static public function locate_template_file( $default_path = '' ) {
-    $custom_path1 = str_replace( self::get_template_dir(), 'woocommerce-pos', $default_path );
+  static public function locate_template_file( $default_path = '', $partials_dir = '' ) {
+    $custom_path1 = str_replace( $partials_dir ?: self::get_template_dir(), 'woocommerce-pos', $default_path );
     $custom_path2 = str_replace( 'tmpl-', '', $custom_path1 );
     $custom = locate_template( array( $custom_path1, $custom_path2 ) );
 


### PR DESCRIPTION
this might be fixed in 0.5 but I can't really test right now as I'm developing on a WC 3.0 install and don't have time to setup something proper with 2.6

and also as I needed this I thought it might be useful to 0.4 for now
I can port it to 0.5 if necessary

anyways 

seemed like it was not possible to add custom templates for Pos Pro Screens

this fix passes along the pos pro template dir path so it can be used as the string to be replaced when building the theme woocommerce-pos template dir path

without this fix the `locate_template_file` method would not replace the template dir path as it was set to the woocommerce pos template dir path and not found in the template path passed to the method